### PR TITLE
cache path slash overlap problem fix

### DIFF
--- a/libraries/Twig.php
+++ b/libraries/Twig.php
@@ -45,7 +45,7 @@ class Twig
 		// default config
 		$this->config = [
 			'paths' => [VIEWPATH],
-			'cache' => APPPATH . '/cache/twig',
+			'cache' => APPPATH . 'cache/twig',
 		];
 
 		$this->config = array_merge($this->config, $params);


### PR DESCRIPTION
default cache path slash overlap problem fix

Default cache path
- application//cache/twig

Amended code
- application/cache/twig
