### PR TITLE
Compatible with newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ codeigniter/
 ## Requirements
 
 * PHP 5.4.0 or later
+* Twig 1.22.0 or later (Also, simply checked with Twig v2.x)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "twig/twig": "~1.20"
+        "twig/twig": "~1.22"
     },
     "require-dev": {
         "codeigniter/framework": "3.1.*",

--- a/libraries/Twig.php
+++ b/libraries/Twig.php
@@ -92,7 +92,7 @@ class Twig
 		$this->config = [
 			'cache'      => APPPATH . 'cache/twig',
 			'debug'      => ENVIRONMENT !== 'production',
-			'autoescape' => TRUE,
+			'autoescape' => 'html',
 		];
 
 		$this->config = array_merge($this->config, $params);


### PR DESCRIPTION
Hi,

Recently, I had a problem with using your codeigniter-ss-twig library on Twig v2.2. I know you didn't mention that this library supports Twig v2.x, but I simply checked and realize that I can use this library on Twig v2.x as well.

This PR simply changed deprecated option value in twig 1.21 to support later versions.
http://twig.sensiolabs.org/doc/1.x/deprecated.html#miscellaneous